### PR TITLE
fix premature end of JPEG file bug

### DIFF
--- a/lib/zbar.ex
+++ b/lib/zbar.ex
@@ -73,6 +73,8 @@ defmodule Zbar do
         | no_return()
   defp collect_output(port, timeout, buffer \\ "") do
     receive do
+      {^port, {:data, "Premature end of JPEG file\n"}} -> #https://github.com/GregMefford/zbar-elixir/issues/1
+        collect_output(port, timeout, buffer)
       {^port, {:data, data}} ->
         collect_output(port, timeout, buffer <> to_string(data))
       {^port, {:exit_status, 0}} ->
@@ -124,8 +126,8 @@ defmodule Zbar do
         "points" ->
           %Symbol{acc | points: parse_points(value)}
 
-          "data" ->
-            %Symbol{acc | data: Base.decode64!(value)}
+        "data" ->
+          %Symbol{acc | data: Base.decode64!(value)}
       end
     end)
   end


### PR DESCRIPTION
fix #1 

- If photo has no barcodes and file don't have EOI 0xFF, 0xD9 - zbar return {:error, "Premature end of JPEG file\n"} and all works correctly.

- But If photo has barcode, zbar return {:ok, data: barcode_dada} and {:ok, data: "Premature end of JPEG file\n"} 

All we need - add new clause and skip information about broken file - as result - we have barcode on broken file too, and application not raise.